### PR TITLE
feat: Add Spring Boot 3 Auto-Configuration for stride-common

### DIFF
--- a/src/main/java/com/stride/stride_common/config/StrideCommonAutoConfiguration.java
+++ b/src/main/java/com/stride/stride_common/config/StrideCommonAutoConfiguration.java
@@ -1,0 +1,10 @@
+package com.stride.stride_common.config;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+
+@AutoConfiguration
+@ComponentScan(basePackages = "com.stride.stride_common")
+public class StrideCommonAutoConfiguration {
+
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.stride.stride_common.config.StrideCommonAutoConfiguration


### PR DESCRIPTION
## Changes
- ✅ Added `StrideCommonAutoConfiguration` class with `@ComponentScan`
- ✅ Created `AutoConfiguration.imports` file for Spring Boot 3 compatibility
- ✅ Enables automatic component discovery for all stride-common beans

## Problem Solved
- Resolves `UnsatisfiedDependencyException` for `JwtTokenProvider` in user-service
- Eliminates need for manual `@ComponentScan` configuration in consuming services
- Follows Spring Boot 3 best practices (replaces deprecated `spring.factories`)

## Testing
- ✅ stride-common builds successfully
- ✅ Auto-configuration class properly annotated
- ✅ Ready for user-service integration testing

## Impact
- All future stride services will automatically inherit stride-common components
- No manual configuration needed in consuming applications
- Professional Spring Boot library pattern